### PR TITLE
Fix error on Frontend New Subscription Page

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( spree/frontend/stripe.js )


### PR DESCRIPTION
Clicking Subscribe on `/recurring/plans` page results in exception which is fixed now

## Exception stacktrace

```ruby
Started GET "/recurring/plans/2/subscriptions/new" for ::1 at 2017-01-17 15:32:13 +0530
  ActiveRecord::SchemaMigration Load (1.6ms)  SELECT "schema_migrations".* FROM "schema_migrations"
Processing by Spree::SubscriptionsController#new as HTML
  Parameters: {"plan_id"=>"2"}
  Spree::User Load (8.3ms)  SELECT  "spree_users".* FROM "spree_users" WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = ?  ORDER BY "spree_users"."id" ASC LIMIT 1  [["id", 1]]
   (1.1ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = ? AND "spree_roles"."name" = ?  [["user_id", 1], ["name", "admin"]]
  Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences" WHERE "spree_preferences"."key" = ? LIMIT 1  [["key", "spree/frontend_configuration/locale"]]
  Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores" WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
  Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores" WHERE "spree_stores"."default" = ?  ORDER BY "spree_stores"."id" ASC LIMIT 1  [["default", "t"]]
  Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = ? AND "spree_orders"."guest_token" = ? AND "spree_orders"."store_id" = ? AND "spree_orders"."user_id" = ? LIMIT 1  [["currency", "USD"], ["guest_token", "x7SgcyIsi0kZdifC5HAqrw1483699917940"], ["store_id", 1], ["user_id", 1]]
  Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."user_id" = ? AND "spree_orders"."completed_at" IS NULL  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
  Spree::Plan Load (0.5ms)  SELECT  "spree_plans".* FROM "spree_plans" WHERE (spree_plans.deleted_at IS NULL) AND "spree_plans"."active" = ? AND "spree_plans"."id" = ?  ORDER BY "spree_plans"."id" ASC LIMIT 1  [["active", "t"], ["id", 2]]
  Spree::Subscription Load (0.3ms)  SELECT  "spree_subscriptions".* FROM "spree_subscriptions" WHERE "spree_subscriptions"."user_id" = ? AND (spree_subscriptions.unsubscribed_at IS NULL)  ORDER BY "spree_subscriptions"."id" ASC LIMIT 1  [["user_id", 1]]
  Rendered /Users/pikender/spree/spree/frontend/app/views/spree/shared/_error_messages.html.erb (3.8ms)
  Spree::Recurring Load (0.6ms)  SELECT  "spree_recurrings".* FROM "spree_recurrings" WHERE "spree_recurrings"."id" = ? LIMIT 1  [["id", 1]]
  Rendered /Users/pikender/spree/marketing/stripe/spree-account-recurring/app/views/spree/subscriptions/new.html.erb within spree/layouts/spree_application (3317.4ms)
Completed 500 Internal Server Error in 3635ms (ActiveRecord: 16.4ms)

ActionView::Template::Error (Asset was not declared to be precompiled in production.
Add `Rails.application.config.assets.precompile += %w( spree/frontend/stripe.js )` to `config/initializers/assets.rb` and restart your server):
    33: <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
    34: <script type="text/javascript">Stripe.setPublishableKey("<%= @plan.provider.preferred_public_key %>");</script>
    35: <script>Spree.stripePaymentMethod = $('#plan_' + <%= @plan.id %> + '_subscribe')</script>
    36: <%= javascript_include_tag "spree/frontend/stripe" %>
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:363:in `raise_unless_precompiled_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:348:in `find_debug_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:229:in `block in lookup_debug_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:242:in `block in resolve_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:241:in `each'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:241:in `detect'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:241:in `resolve_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:228:in `lookup_debug_asset'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:141:in `block in javascript_include_tag'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:140:in `map'
  sprockets-rails (3.2.0) lib/sprockets/rails/helper.rb:140:in `javascript_include_tag'
  /Users/pikender/spree/marketing/stripe/spree-account-recurring/app/views/spree/subscriptions/new.html.erb:36:in `_a050ef977821be2f0cf6ab3c8f1050c4'
  actionview (4.2.7.1) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.7.1) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.7.1) lib/action_view/template.rb:143:in `render'
  deface (1.0.2) lib/deface/action_view_extensions.rb:41:in `render'
  actionview (4.2.7.1) lib/action_view/renderer/template_renderer.rb:54:in `block (2 levels) in render_template'
  actionview (4.2.7.1) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.7.1) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.7.1) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.7.1) lib/action_view/renderer/template_renderer.rb:53:in `block in render_template'
  actionview (4.2.7.1) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
  actionview (4.2.7.1) lib/action_view/renderer/template_renderer.rb:52:in `render_template'
  actionview (4.2.7.1) lib/action_view/renderer/template_renderer.rb:14:in `render'
  actionview (4.2.7.1) lib/action_view/renderer/renderer.rb:46:in `render_template'
  actionview (4.2.7.1) lib/action_view/renderer/renderer.rb:27:in `render'
  actionview (4.2.7.1) lib/action_view/rendering.rb:100:in `_render_template'
  actionpack (4.2.7.1) lib/action_controller/metal/streaming.rb:217:in `_render_template'
  actionview (4.2.7.1) lib/action_view/rendering.rb:83:in `render_to_body'
  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:32:in `render_to_body'
  actionpack (4.2.7.1) lib/action_controller/metal/renderers.rb:37:in `render_to_body'
  actionpack (4.2.7.1) lib/abstract_controller/rendering.rb:25:in `render'
  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
  activesupport (4.2.7.1) lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
  /Users/pikender/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
  activesupport (4.2.7.1) lib/active_support/core_ext/benchmark.rb:12:in `ms'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:44:in `block in render'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
  activerecord (4.2.7.1) lib/active_record/railties/controller_runtime.rb:25:in `cleanup_view_runtime'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:43:in `render'
  actionpack (4.2.7.1) lib/action_controller/metal/implicit_render.rb:10:in `default_render'
  actionpack (4.2.7.1) lib/action_controller/metal/implicit_render.rb:5:in `send_action'
  actionpack (4.2.7.1) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.7.1) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
  activerecord (4.2.7.1) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (4.2.7.1) lib/abstract_controller/base.rb:137:in `process'
  actionview (4.2.7.1) lib/action_view/rendering.rb:30:in `process'
  actionpack (4.2.7.1) lib/action_controller/metal.rb:196:in `dispatch'
  actionpack (4.2.7.1) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.7.1) lib/action_controller/metal.rb:237:in `block in action'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:74:in `dispatch'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:43:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `each'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:817:in `call'
  railties (4.2.7.1) lib/rails/engine.rb:518:in `call'
  railties (4.2.7.1) lib/rails/railtie.rb:194:in `public_send'
  railties (4.2.7.1) lib/rails/railtie.rb:194:in `method_missing'
  actionpack (4.2.7.1) lib/action_dispatch/routing/mapper.rb:51:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `each'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:817:in `call'
  warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.6) lib/warden/manager.rb:34:in `catch'
  warden (1.2.6) lib/warden/manager.rb:34:in `call'
  rack (1.6.5) lib/rack/etag.rb:24:in `call'
  rack (1.6.5) lib/rack/conditionalget.rb:25:in `call'
  rack (1.6.5) lib/rack/head.rb:13:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.5) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.5) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.7.1) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.7.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  activerecord (4.2.7.1) lib/active_record/migration.rb:377:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  web-console (2.3.0) lib/web_console/middleware.rb:28:in `block in call'
  web-console (2.3.0) lib/web_console/middleware.rb:18:in `catch'
  web-console (2.3.0) lib/web_console/middleware.rb:18:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.7.1) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.5) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.5) lib/rack/runtime.rb:18:in `call'
  activesupport (4.2.7.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  rack (1.6.5) lib/rack/lock.rb:17:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/static.rb:120:in `call'
  rack (1.6.5) lib/rack/sendfile.rb:113:in `call'
  railties (4.2.7.1) lib/rails/engine.rb:518:in `call'
  railties (4.2.7.1) lib/rails/application.rb:165:in `call'
  rack (1.6.5) lib/rack/lock.rb:17:in `call'
  rack (1.6.5) lib/rack/content_length.rb:15:in `call'
  rack (1.6.5) lib/rack/handler/webrick.rb:88:in `service'
  /Users/pikender/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:140:in `service'
  /Users/pikender/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:96:in `run'
  /Users/pikender/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/server.rb:296:in `block in start_thread'
```

