### PR TITLE
When user has subscribed for a plan, should show unsubscribe on Plan Listing

### DIFF
--- a/app/controllers/spree/plans_controller.rb
+++ b/app/controllers/spree/plans_controller.rb
@@ -1,6 +1,6 @@
 module Spree
   class PlansController < StoreController
-    before_filter :load_user_subscriptions
+    before_action :load_user_subscriptions
 
     def index
       @plans = Spree::Plan.visible.order('id desc')

--- a/app/controllers/spree/plans_controller.rb
+++ b/app/controllers/spree/plans_controller.rb
@@ -1,7 +1,18 @@
 module Spree
   class PlansController < StoreController
+    before_filter :load_user_subscriptions
+
     def index
       @plans = Spree::Plan.visible.order('id desc')
     end
+
+    private
+      def load_user_subscriptions
+        if spree_current_user
+          @user_subscriptions = spree_current_user.subscriptions.undeleted.all.to_a
+        else
+          @user_subscriptions = []
+        end
+      end
   end
 end

--- a/app/views/spree/plans/index.html.erb
+++ b/app/views/spree/plans/index.html.erb
@@ -8,7 +8,7 @@
     <br/>
     <% if spree_current_user %>
       <% if subscription = @user_subscriptions.find {|s| s.plan_id == plan.id } %>
-        <%= button_link_to Spree.t(:unsubscribe), recurring_plan_subscription_url(plan, subscription), method: :delete, :confirm => "Do you want to unsubscribe ?" %>
+        <%= button_link_to Spree.t(:unsubscribe), recurring_plan_subscription_url(plan, subscription), method: :delete, confirm: "Do you want to unsubscribe ?" %>
       <% else %>
         <%= button_link_to 'Subscribe', new_recurring_plan_subscription_url(plan) %>
       <% end %>

--- a/app/views/spree/plans/index.html.erb
+++ b/app/views/spree/plans/index.html.erb
@@ -7,7 +7,11 @@
     <%= plan.trial_period_days %> <%= 'day'.pluralize(plan.trial_period_days) %> trial <br/>
     <br/>
     <% if spree_current_user %>
-      <%= button_link_to 'Subscribe', new_recurring_plan_subscription_url(plan) %>
+      <% if subscription = @user_subscriptions.find {|s| s.plan_id == plan.id } %>
+        <%= button_link_to Spree.t(:unsubscribe), recurring_plan_subscription_url(plan, subscription), method: :delete, :confirm => "Do you want to unsubscribe ?" %>
+      <% else %>
+        <%= button_link_to 'Subscribe', new_recurring_plan_subscription_url(plan) %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/spree/subscriptions/show.html.erb
+++ b/app/views/spree/subscriptions/show.html.erb
@@ -1,4 +1,4 @@
 <%= @subscription.plan.api_plan_id %>
 <% unless @subscription.is_destroyed? %>
-  <%= button_link_to Spree.t(:unsubscribe), recurring_plan_subscription_url(@plan, @subscription), method: :delete, :confirm => "Do you want to unsubscribe ?" %>
+  <%= button_link_to Spree.t(:unsubscribe), recurring_plan_subscription_url(@plan, @subscription), method: :delete, confirm: "Do you want to unsubscribe ?" %>
 <% end %>

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'stripe', '1.16.0'
   s.add_dependency 'stripe_tester'
 
-  s.add_development_dependency 'rspec-rails',  '~> 2.13'
+  s.add_development_dependency 'rspec-rails',  '~> 3.4'
 end


### PR DESCRIPTION
Currently, Plan Listing shows Subscribe always and clicking on it checks for whether subscribed or not and redirects to show subscription page and shows Unsubscribe correctly