### PR TITLE
Prepared for 3.2.x and Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,9 @@ group :assets do
 end
 
 # Provides basic frontend and backend functionalities for testing purposes
-gem 'spree', github: 'spree/spree', branch: '3-1-stable'
-
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
 group :test do
   gem 'shoulda-matchers', '~> 2.8.0'

--- a/app/controllers/spree/admin/recurrings_controller.rb
+++ b/app/controllers/spree/admin/recurrings_controller.rb
@@ -64,7 +64,7 @@ module Spree
       end
 
       def preference_params
-        params[ActiveModel::Naming.param_key(@recurring)]
+        params.require(ActiveModel::Naming.param_key(@recurring)).permit!
       end
     end
   end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( spree/frontend/stripe.js )

--- a/spec/models/spree/subscription_event_spec.rb
+++ b/spec/models/spree/subscription_event_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe Spree::SubscriptionEvent do
-  it { should serialize :response }
+  it "should serialize :response" do
+    # Note: shoulda has a Rails5 bug for serialize bug https://github.com/thoughtbot/shoulda-matchers/issues/913
+    # Added an equivalent test, can be reverted back to shoulda version when fixed
+    expect(Spree::SubscriptionEvent.type_for_attribute("response")).to be_kind_of(::ActiveRecord::Type::Serialized)
+  end
+
   it { should belong_to :subscription }
   it { should validate_presence_of :event_id }
   it { should validate_presence_of :subscription_id }

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_account_recurring'
-  s.version     = '2.1.0'
+  s.version     = '2.2.0'
   s.summary     = 'Spree extension to manage recurring payments/subscriptions using Stripe Payment Gateway.'
   s.description = s.summary
   s.required_ruby_version = '>= 2.1.0'
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.1.0'
+  s.add_dependency 'spree_core', '~> 3.2.0.rc2'
   s.add_dependency 'stripe', '1.16.0'
   s.add_dependency 'stripe_tester'
 


### PR DESCRIPTION
Fixed Strong Parameters issue - not saving stripe keys
Fixed ActionView::Template::Error
 (Asset was not declared to be precompiled in production.
 Add Rails.application.config.assets.precompile += %w(spree/frontend/stripe.js )
 to config/initializers/assets.rb and restart your server):
Added alternate for serailize :response due to bug in shoulda matchers
 https://github.com/thoughtbot/shoulda-matchers/issues/913